### PR TITLE
Fix companyName missing err. Works out of box now

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const app = electron.app;  // Module to control application life.
 const BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.
 
 // Report crashes to our server.
-electron.crashReporter.start();
+//electron.crashReporter.start();
 
 
 // Keep a global reference of the window object, if you don't, the window will


### PR DESCRIPTION
Crash Reporter requires you to provide companyName and submitURL for it to work.
https://github.com/electron/electron/blob/master/docs/api/crash-reporter.md#crashreporterstartoptions